### PR TITLE
refactor: 카테고리를 enum타입으로 관리되도록 리팩토링

### DIFF
--- a/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskCommand.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskCommand.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.sopt.todomate.domain.maintask.domain.entity.CategoryType;
 import com.sopt.todomate.domain.maintask.domain.entity.RoutineType;
 import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskCreateRequest;
 
@@ -14,7 +15,7 @@ public record MainTaskCommand(
 	LocalDateTime endAt,
 	RoutineType routineType,
 	long priority,
-	String category,
+	CategoryType category,
 	LocalDateTime taskDate,
 	boolean completed,
 	List<SubTaskCommand> subTasks

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/CategoryType.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/CategoryType.java
@@ -1,0 +1,31 @@
+package com.sopt.todomate.domain.maintask.domain.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.sopt.todomate.domain.maintask.exception.InvalidCategoryTypeException;
+
+public enum CategoryType {
+	CATEGORY1("카테고리1"),
+	CATEGORY2("카테고리2"),
+	CATEGORY3("카테고리3");
+
+	private final String label;
+
+	CategoryType(String label) {
+		this.label = label;
+	}
+
+	@JsonCreator
+	public static CategoryType fromValue(String value) {
+
+		for (CategoryType type : values()) {
+			if (type.label.equals(value)) return type;
+		}
+		throw new InvalidCategoryTypeException();
+	}
+
+	@JsonValue
+	public String getLabel() {
+		return label;
+	}
+}

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/MainTask.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/MainTask.java
@@ -47,6 +47,7 @@ public class MainTask extends BaseEntity {
 	@Column(name = "priority")
 	private Long priority;
 
+	@Enumerated(EnumType.STRING)
 	@Column(name = "category", nullable = false)
 	private String category;
 

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/MainTask.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/MainTask.java
@@ -49,7 +49,7 @@ public class MainTask extends BaseEntity {
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "category", nullable = false)
-	private String category;
+	private CategoryType category;
 
 	@Column(name = "task_date", nullable = false)
 	private LocalDateTime taskDate;
@@ -67,7 +67,7 @@ public class MainTask extends BaseEntity {
 	@Builder
 	private MainTask(String taskContent, LocalDateTime startAt, LocalDateTime endAt, RoutineType routineType,
 		Long priority,
-		String category, LocalDateTime taskDate, User user, Boolean completed, long templateTaskId) {
+		CategoryType category, LocalDateTime taskDate, User user, Boolean completed, long templateTaskId) {
 		this.taskContent = taskContent;
 		this.startAt = startAt;
 		this.endAt = endAt;

--- a/src/main/java/com/sopt/todomate/domain/maintask/exception/InvalidCategoryTypeException.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/exception/InvalidCategoryTypeException.java
@@ -1,0 +1,10 @@
+package com.sopt.todomate.domain.maintask.exception;
+
+import com.sopt.todomate.global.common.exception.BusinessException;
+import com.sopt.todomate.global.common.exception.constant.ExceptionCode;
+
+public class InvalidCategoryTypeException extends BusinessException {
+	public InvalidCategoryTypeException() {
+		super(ExceptionCode.INVALID_CATEGORY_TYPE);
+	}
+}

--- a/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskCreateRequest.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskCreateRequest.java
@@ -3,6 +3,7 @@ package com.sopt.todomate.domain.maintask.presentation.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.sopt.todomate.domain.maintask.domain.entity.CategoryType;
 import com.sopt.todomate.domain.maintask.domain.entity.RoutineType;
 
 import jakarta.validation.constraints.NotBlank;
@@ -16,8 +17,8 @@ public record MainTaskCreateRequest(
 	@NotNull(message = "루틴 종류는 비어있을 수 없습니다.")
 	RoutineType routineType,
 	long priority,
-	@NotBlank(message = "카테고리는 비어있을 수 없습니다.")
-	String category,
+	@NotNull(message = "카테고리는 비어있을 수 없습니다.")
+	CategoryType category,
 	@NotNull(message = "일정 날짜는 비어있을 수 없습니다.")
 	LocalDateTime taskDate,
 	@NotNull(message = "완료 여부는 비어있을 수 없습니다.")

--- a/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskCreateResponse.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskCreateResponse.java
@@ -3,6 +3,7 @@ package com.sopt.todomate.domain.maintask.presentation.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.sopt.todomate.domain.maintask.domain.entity.CategoryType;
 import com.sopt.todomate.domain.maintask.domain.entity.MainTask;
 import com.sopt.todomate.domain.maintask.domain.entity.RoutineType;
 import com.sopt.todomate.domain.subtask.domain.entity.SubTask;
@@ -14,7 +15,7 @@ public record MainTaskCreateResponse(
 	LocalDateTime endAt,
 	RoutineType routineType,
 	long priority,
-	String category,
+	CategoryType category,
 	LocalDateTime taskDate,
 	boolean completed,
 	List<SubTaskResponse> subTasks

--- a/src/main/java/com/sopt/todomate/global/common/exception/constant/ExceptionCode.java
+++ b/src/main/java/com/sopt/todomate/global/common/exception/constant/ExceptionCode.java
@@ -8,6 +8,7 @@ public enum ExceptionCode {
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "c4000", "잘못된 요청입니다."),
 	EMPTY_USER_ID(HttpStatus.BAD_REQUEST, "c40010", "유저ID는 필수입니다."),
 	INVALID_ROUTINE_TYPE(HttpStatus.BAD_REQUEST, "c40011", "유효하지 않은 루틴타입 입니다."),
+	INVALID_CATEGORY_TYPE(HttpStatus.BAD_REQUEST, "c40012", "유효하지 않은 카테고리 타입 입니다."),
 	EMPTY_ROUTINE_DATE(HttpStatus.BAD_REQUEST, "c40021", "루틴 생성시 날짜는 모두 입력되어야 합니다."),
 
 	//404

--- a/src/test/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecaseTest.java
+++ b/src/test/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecaseTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sopt.todomate.domain.maintask.application.dto.MainTaskCommand;
+import com.sopt.todomate.domain.maintask.domain.entity.CategoryType;
 import com.sopt.todomate.domain.maintask.domain.entity.MainTask;
 import com.sopt.todomate.domain.maintask.domain.entity.RoutineType;
 import com.sopt.todomate.domain.maintask.domain.repository.MainTaskRepository;
@@ -58,7 +59,7 @@ public class MainTaskManageUsecaseTest {
 			null,       // endAt
 			RoutineType.NONE,       // routinCycle
 			1,        // priority
-			"Work",     // category
+			CategoryType.CATEGORY1,     // category
 			now,        // taskDate
 			false,      // completed
 			List.of(new SubTaskDto("통합테스트 서브태스크", false))
@@ -103,7 +104,7 @@ public class MainTaskManageUsecaseTest {
 			endDate,    // endAt
 			RoutineType.DAILY,    // routinCycle
 			2,          // priority
-			"Work",     // category
+			CategoryType.CATEGORY1,     // category
 			now,       // taskDate
 			false,      // completed
 			List.of(new SubTaskDto("반복 서브태스크", false))
@@ -141,7 +142,7 @@ public class MainTaskManageUsecaseTest {
 		for (MainTask task : savedMainTasks) {
 			assertEquals("반복 태스크", task.getTaskContent());
 			assertEquals(2L, task.getPriority());
-			assertEquals("Work", task.getCategory());
+			assertEquals(CategoryType.CATEGORY1, task.getCategory());
 			assertEquals(RoutineType.DAILY, task.getRoutineType());
 			assertEquals(now, task.getStartAt());
 			assertEquals(endDate, task.getEndAt());


### PR DESCRIPTION
## 🚀 PR 요약
카테고리를 enum타입으로 관리되도록 변경

## ✨ PR 상세 내용
- 기존 문자열(String)로 관리되던 메인 태스크의 카테고리 필드를 CategoryType enum으로 리팩토링했습니다.
- 프론트에서 넘겨주는 값이 유효한 카테고리(enum에 정의된 값)인지 검증할 수 있도록 @JsonCreator를 사용한 역직렬화 처리를 추가했습니다.
- 유효하지 않은 값이 들어올 경우 예외(InvalidCategoryTypeException)를 발생시키도록 했으며, ExceptionCode에 INVALID_CATEGORY_TYPE 항목을 추가했습니다. 
(사실 enum만 추가해도 되는데 괜히 했나 싶네요.. 저희 카테고리에 따른 필터링 기능도 없는데.. )

## 🚨 주의 사항
딱히 없습니다.

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?
