### PR TITLE
[feat] 태스크 수정 API 구현

### DIFF
--- a/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskCommand.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskCommand.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import com.sopt.todomate.domain.maintask.domain.entity.CategoryType;
+import com.sopt.todomate.domain.maintask.domain.entity.Importance;
 import com.sopt.todomate.domain.maintask.domain.entity.RoutineType;
 import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskCreateRequest;
 
@@ -14,7 +15,7 @@ public record MainTaskCommand(
 	LocalDateTime startAt,
 	LocalDateTime endAt,
 	RoutineType routineType,
-	long priority,
+	Importance importance,
 	CategoryType category,
 	LocalDateTime taskDate,
 	boolean completed,
@@ -32,7 +33,7 @@ public record MainTaskCommand(
 			request.startAt(),
 			request.endAt(),
 			request.routineType(),
-			request.priority(),
+			request.importance(),
 			request.category(),
 			request.taskDate(),
 			request.completed(),

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskUpdateCommand.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskUpdateCommand.java
@@ -3,6 +3,7 @@ package com.sopt.todomate.domain.maintask.application.dto;
 import java.util.List;
 
 import com.sopt.todomate.domain.maintask.domain.entity.Importance;
+import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskUpdateRequest;
 
 public record MainTaskUpdateCommand(
 	String taskContent,
@@ -10,4 +11,12 @@ public record MainTaskUpdateCommand(
 	Importance importance,
 	boolean changeAll
 ) {
+	public static MainTaskUpdateCommand from(MainTaskUpdateRequest request) {
+		return new MainTaskUpdateCommand(
+			request.taskContent(),
+			request.subTasks(),
+			request.importance(),
+			request.changeAll()
+		);
+	}
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskUpdateCommand.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskUpdateCommand.java
@@ -2,9 +2,12 @@ package com.sopt.todomate.domain.maintask.application.dto;
 
 import java.util.List;
 
+import com.sopt.todomate.domain.maintask.domain.entity.Importance;
+
 public record MainTaskUpdateCommand(
 	String taskContent,
 	List<SubTaskUpdateCommand> subTasks,
+	Importance importance,
 	boolean changeAll
 ) {
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskUpdateCommand.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskUpdateCommand.java
@@ -2,17 +2,20 @@ package com.sopt.todomate.domain.maintask.application.dto;
 
 import java.util.List;
 
+import com.sopt.todomate.domain.maintask.domain.entity.Importance;
 import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskUpdateRequest;
 
 public record MainTaskUpdateCommand(
 	String taskContent,
 	List<SubTaskUpdateCommand> subTasks,
+	Importance importance,
 	boolean changeAll
 ) {
 	public static MainTaskUpdateCommand from(MainTaskUpdateRequest request) {
 		return new MainTaskUpdateCommand(
 			request.taskContent(),
 			request.subTasks(),
+			request.importance(),
 			request.changeAll()
 		);
 	}

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskUpdateCommand.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskUpdateCommand.java
@@ -2,20 +2,17 @@ package com.sopt.todomate.domain.maintask.application.dto;
 
 import java.util.List;
 
-import com.sopt.todomate.domain.maintask.domain.entity.Importance;
 import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskUpdateRequest;
 
 public record MainTaskUpdateCommand(
 	String taskContent,
 	List<SubTaskUpdateCommand> subTasks,
-	Importance importance,
 	boolean changeAll
 ) {
 	public static MainTaskUpdateCommand from(MainTaskUpdateRequest request) {
 		return new MainTaskUpdateCommand(
 			request.taskContent(),
 			request.subTasks(),
-			request.importance(),
 			request.changeAll()
 		);
 	}

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskUpdateCommand.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskUpdateCommand.java
@@ -1,0 +1,10 @@
+package com.sopt.todomate.domain.maintask.application.dto;
+
+import java.util.List;
+
+public record MainTaskUpdateCommand(
+	String taskContent,
+	List<SubTaskUpdateCommand> subTasks,
+	boolean changeAll
+) {
+}

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/dto/SubTaskUpdateCommand.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/dto/SubTaskUpdateCommand.java
@@ -5,9 +5,10 @@ import com.sopt.todomate.domain.subtask.domain.entity.SubTask;
 
 public record SubTaskUpdateCommand(
 	long id,
-	String content
+	String content,
+	boolean completed
 ) {
-	public SubTask toEntity(MainTask mainTask) {
-		return SubTask.createCompletedFalse(this.content, mainTask);
+	public SubTask toEntity(MainTask mainTask, boolean completed) {
+		return SubTask.create(this.content, mainTask, completed);
 	}
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/dto/SubTaskUpdateCommand.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/dto/SubTaskUpdateCommand.java
@@ -1,0 +1,7 @@
+package com.sopt.todomate.domain.maintask.application.dto;
+
+public record SubTaskUpdateCommand(
+	long id,
+	String content
+) {
+}

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/dto/SubTaskUpdateCommand.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/dto/SubTaskUpdateCommand.java
@@ -4,7 +4,6 @@ import com.sopt.todomate.domain.maintask.domain.entity.MainTask;
 import com.sopt.todomate.domain.subtask.domain.entity.SubTask;
 
 public record SubTaskUpdateCommand(
-	long id,
 	String content,
 	boolean completed
 ) {

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/dto/SubTaskUpdateCommand.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/dto/SubTaskUpdateCommand.java
@@ -1,7 +1,13 @@
 package com.sopt.todomate.domain.maintask.application.dto;
 
+import com.sopt.todomate.domain.maintask.domain.entity.MainTask;
+import com.sopt.todomate.domain.subtask.domain.entity.SubTask;
+
 public record SubTaskUpdateCommand(
 	long id,
 	String content
 ) {
+	public SubTask toEntity(MainTask mainTask) {
+		return SubTask.createCompletedFalse(this.content, mainTask);
+	}
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
@@ -21,6 +21,7 @@ import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskCreateResponse
 import com.sopt.todomate.domain.subtask.domain.entity.SubTask;
 import com.sopt.todomate.domain.subtask.domain.service.SubTaskGetService;
 import com.sopt.todomate.domain.subtask.domain.service.SubTaskSaveService;
+import com.sopt.todomate.domain.subtask.exception.SubTaskNotIncludeException;
 import com.sopt.todomate.domain.user.domain.entity.User;
 import com.sopt.todomate.domain.user.domain.service.UserGetService;
 
@@ -123,7 +124,7 @@ public class MainTaskManageUsecase {
 			SubTask subTask = subTaskGetService.findSubTaskById(subTaskCmd.id());
 
 			if (!subTask.getMainTask().getId().equals(mainTask.getId())) {
-				throw new IllegalArgumentException("해당 서브태스크는 메인태스크에 속하지 않습니다.");
+				throw new SubTaskNotIncludeException();
 			}
 			subTask.updateContent(subTaskCmd.content());
 		}

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
@@ -22,7 +22,6 @@ import com.sopt.todomate.domain.subtask.domain.entity.SubTask;
 import com.sopt.todomate.domain.subtask.domain.service.SubTaskDeleteService;
 import com.sopt.todomate.domain.subtask.domain.service.SubTaskGetService;
 import com.sopt.todomate.domain.subtask.domain.service.SubTaskSaveService;
-import com.sopt.todomate.domain.subtask.exception.SubTaskNotIncludeException;
 import com.sopt.todomate.domain.user.domain.entity.User;
 import com.sopt.todomate.domain.user.domain.service.UserGetService;
 
@@ -129,7 +128,7 @@ public class MainTaskManageUsecase {
 				subTaskDeleteService.deleteAllByMainTask(routineTask);
 
 				List<SubTask> subTasks = command.subTasks().stream()
-					.map(updateCommand -> updateCommand.toEntity(routineTask))
+					.map(updateCommand -> updateCommand.toEntity(routineTask, false))
 					.toList();
 
 				subTaskSaveService.saveAll(subTasks);
@@ -138,13 +137,12 @@ public class MainTaskManageUsecase {
 	}
 
 	private void updateSubTasks(MainTask mainTask, List<SubTaskUpdateCommand> subTaskCommands) {
-		for (SubTaskUpdateCommand subTaskCmd : subTaskCommands) {
-			SubTask subTask = subTaskGetService.findSubTaskById(subTaskCmd.id());
+		subTaskDeleteService.deleteAllByMainTask(mainTask);
 
-			if (!subTask.getMainTask().getId().equals(mainTask.getId())) {
-				throw new SubTaskNotIncludeException();
-			}
-			subTask.updateContent(subTaskCmd.content());
-		}
+		List<SubTask> subTasks = subTaskCommands.stream()
+			.map(updateCommand -> updateCommand.toEntity(mainTask, updateCommand.completed()))
+			.toList();
+
+		subTaskSaveService.saveAll(subTasks);
 	}
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
@@ -118,7 +118,6 @@ public class MainTaskManageUsecase {
 		User user = userGetService.findByUserId(userId);
 		MainTask mainTask = checkAuthorityByMainTaskId(mainTaskId, user);
 		mainTask.updateContent(command.taskContent());
-		mainTask.updateImportance(command.importance());
 		updateSubTasks(mainTask, command.subTasks());
 
 		if (command.changeAll()) {
@@ -127,7 +126,6 @@ public class MainTaskManageUsecase {
 
 			for (MainTask routineTask : mainTasks) {
 				routineTask.updateContent(command.taskContent());
-				mainTask.updateImportance(command.importance());
 				subTaskDeleteService.deleteAllByMainTask(routineTask);
 
 				List<SubTask> subTasks = command.subTasks().stream()

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
@@ -118,6 +118,7 @@ public class MainTaskManageUsecase {
 		User user = userGetService.findByUserId(userId);
 		MainTask mainTask = checkAuthorityByMainTaskId(mainTaskId, user);
 		mainTask.updateContent(command.taskContent());
+		mainTask.updateImportance(command.importance());
 		updateSubTasks(mainTask, command.subTasks());
 
 		if (command.changeAll()) {
@@ -126,6 +127,7 @@ public class MainTaskManageUsecase {
 
 			for (MainTask routineTask : mainTasks) {
 				routineTask.updateContent(command.taskContent());
+				routineTask.updateImportance(command.importance());
 				subTaskDeleteService.deleteAllByMainTask(routineTask);
 
 				List<SubTask> subTasks = command.subTasks().stream()

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
@@ -12,6 +12,7 @@ import com.sopt.todomate.domain.maintask.application.dto.MainTaskCommand;
 import com.sopt.todomate.domain.maintask.application.dto.MainTaskUpdateCommand;
 import com.sopt.todomate.domain.maintask.application.dto.SubTaskCommand;
 import com.sopt.todomate.domain.maintask.application.dto.SubTaskUpdateCommand;
+import com.sopt.todomate.domain.maintask.domain.entity.Importance;
 import com.sopt.todomate.domain.maintask.domain.entity.MainTask;
 import com.sopt.todomate.domain.maintask.domain.entity.RoutineType;
 import com.sopt.todomate.domain.maintask.domain.service.MainTaskGetService;
@@ -20,7 +21,6 @@ import com.sopt.todomate.domain.maintask.exception.EmptyRoutineDateException;
 import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskCreateResponse;
 import com.sopt.todomate.domain.subtask.domain.entity.SubTask;
 import com.sopt.todomate.domain.subtask.domain.service.SubTaskDeleteService;
-import com.sopt.todomate.domain.subtask.domain.service.SubTaskGetService;
 import com.sopt.todomate.domain.subtask.domain.service.SubTaskSaveService;
 import com.sopt.todomate.domain.user.domain.entity.User;
 import com.sopt.todomate.domain.user.domain.service.UserGetService;
@@ -35,7 +35,6 @@ public class MainTaskManageUsecase {
 	private final MainTaskSaveService mainTaskSaveService;
 	private final SubTaskSaveService subTaskSaveService;
 	private final MainTaskGetService mainTaskGetService;
-	private final SubTaskGetService subTaskGetService;
 	private final SubTaskDeleteService subTaskDeleteService;
 
 	@Transactional
@@ -68,7 +67,7 @@ public class MainTaskManageUsecase {
 			.startAt(command.startAt())
 			.endAt(command.endAt())
 			.routineType(command.routineType())
-			.priority(command.priority())
+			.importance(command.importance() == null ? Importance.LOW : command.importance())
 			.category(command.category())
 			.taskDate(taskDate)
 			.user(user)
@@ -117,6 +116,7 @@ public class MainTaskManageUsecase {
 		User user = userGetService.findByUserId(userId);
 		MainTask mainTask = mainTaskGetService.findByMainTaskId(mainTaskId);
 		mainTask.updateContent(command.taskContent());
+		mainTask.updateImportance(command.importance());
 		updateSubTasks(mainTask, command.subTasks());
 
 		if (command.changeAll()) {

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
@@ -2,7 +2,6 @@ package com.sopt.todomate.domain.maintask.application.usecase;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,6 +22,7 @@ import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskCreateResponse
 import com.sopt.todomate.domain.subtask.domain.entity.SubTask;
 import com.sopt.todomate.domain.subtask.domain.service.SubTaskDeleteService;
 import com.sopt.todomate.domain.subtask.domain.service.SubTaskSaveService;
+import com.sopt.todomate.domain.subtask.exception.MaxSubTaskException;
 import com.sopt.todomate.domain.user.domain.entity.User;
 import com.sopt.todomate.domain.user.domain.service.UserGetService;
 
@@ -79,8 +79,9 @@ public class MainTaskManageUsecase {
 	}
 
 	private List<SubTask> createAndSaveSubTasks(List<SubTaskCommand> subTaskCommands, MainTask mainTask) {
-		if (subTaskCommands == null || subTaskCommands.isEmpty()) {
-			return Collections.emptyList();
+
+		if (subTaskCommands.size() > 3) {
+			throw new MaxSubTaskException();
 		}
 
 		List<SubTask> subTasks = subTaskCommands.stream()
@@ -126,6 +127,7 @@ public class MainTaskManageUsecase {
 
 			for (MainTask routineTask : mainTasks) {
 				routineTask.updateContent(command.taskContent());
+				mainTask.updateImportance(command.importance());
 				subTaskDeleteService.deleteAllByMainTask(routineTask);
 
 				List<SubTask> subTasks = command.subTasks().stream()
@@ -149,6 +151,9 @@ public class MainTaskManageUsecase {
 	}
 
 	private void updateSubTasks(MainTask mainTask, List<SubTaskUpdateCommand> subTaskCommands) {
+		if (subTaskCommands.size() > 3) {
+			throw new MaxSubTaskException();
+		}
 		subTaskDeleteService.deleteAllByMainTask(mainTask);
 
 		List<SubTask> subTasks = subTaskCommands.stream()

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/CategoryType.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/CategoryType.java
@@ -1,7 +1,6 @@
 package com.sopt.todomate.domain.maintask.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.sopt.todomate.domain.maintask.exception.InvalidCategoryTypeException;
 
 public enum CategoryType {
@@ -25,7 +24,6 @@ public enum CategoryType {
 		}
 	}
 
-	@JsonValue
 	public String getLabel() {
 		return label;
 	}

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/CategoryType.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/CategoryType.java
@@ -18,10 +18,11 @@ public enum CategoryType {
 	@JsonCreator
 	public static CategoryType fromValue(String value) {
 
-		for (CategoryType type : values()) {
-			if (type.label.equals(value)) return type;
+		try {
+			return CategoryType.valueOf(value.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			throw new InvalidCategoryTypeException();
 		}
-		throw new InvalidCategoryTypeException();
 	}
 
 	@JsonValue

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/Importance.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/Importance.java
@@ -22,13 +22,12 @@ public enum Importance {
 	}
 
 	@JsonCreator
-	public static Importance fromValue(int value) {
-		for (Importance importance : values()) {
-			if (importance.value == value) {
-				return importance;
-			}
+	public static Importance fromValue(String value) {
+		try {
+			return Importance.valueOf(value.toUpperCase());
+		} catch (IllegalArgumentException e) {
+			throw new InvalidImportanceException();
 		}
-		throw new InvalidImportanceException();
 	}
 
 	public static Comparator<Importance> comparator() {

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/Importance.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/Importance.java
@@ -1,0 +1,38 @@
+package com.sopt.todomate.domain.maintask.domain.entity;
+
+import java.util.Comparator;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.sopt.todomate.domain.maintask.exception.InvalidImportanceException;
+
+import lombok.Getter;
+
+@Getter
+public enum Importance {
+	HIGH(3, "상"),
+	MEDIUM(2, "중"),
+	LOW(1, "하");
+
+	private final int value;
+	private final String displayName;
+
+	Importance(int value, String displayName) {
+		this.value = value;
+		this.displayName = displayName;
+	}
+
+	@JsonCreator
+	public static Importance fromValue(int value) {
+		for (Importance importance : values()) {
+			if (importance.value == value) {
+				return importance;
+			}
+		}
+		throw new InvalidImportanceException();
+	}
+
+	public static Comparator<Importance> comparator() {
+		return Comparator.comparing(Importance::getValue).reversed();
+	}
+
+}

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/MainTask.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/MainTask.java
@@ -105,4 +105,8 @@ public class MainTask extends BaseEntity {
 	public void updateTemplateTask(long id) {
 		this.templateTaskId = id;
 	}
+
+	public void updateContent(String content) {
+		this.taskContent = content;
+	}
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/MainTask.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/MainTask.java
@@ -100,4 +100,8 @@ public class MainTask extends BaseEntity {
 	public void updateImportance(Importance importance) {
 		this.importance = importance;
 	}
+
+	public boolean isAuthor(User user) {
+		return this.user.equals(user);
+	}
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/MainTask.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/MainTask.java
@@ -44,8 +44,9 @@ public class MainTask extends BaseEntity {
 	@Column(name = "routin_type", nullable = false)
 	private RoutineType routineType;
 
-	@Column(name = "priority")
-	private Long priority;
+	@Enumerated(EnumType.STRING)
+	@Column(name = "importance", nullable = false)
+	private Importance importance;
 
 	@Enumerated(EnumType.STRING)
 	@Column(name = "category", nullable = false)
@@ -66,32 +67,18 @@ public class MainTask extends BaseEntity {
 
 	@Builder
 	private MainTask(String taskContent, LocalDateTime startAt, LocalDateTime endAt, RoutineType routineType,
-		Long priority,
+		Importance importance,
 		CategoryType category, LocalDateTime taskDate, User user, Boolean completed, long templateTaskId) {
 		this.taskContent = taskContent;
 		this.startAt = startAt;
 		this.endAt = endAt;
 		this.routineType = routineType;
-		this.priority = priority;
+		this.importance = importance;
 		this.category = category;
 		this.taskDate = taskDate;
 		this.user = user;
 		this.completed = completed;
 		this.templateTaskId = templateTaskId;
-	}
-
-	public static MainTask createRecurring(String content, User user, LocalDateTime taskDate,
-		LocalDateTime startAt, LocalDateTime endAt,
-		RoutineType routineType) {
-		return builder()
-			.taskContent(content)
-			.taskDate(taskDate)
-			.startAt(startAt)
-			.endAt(endAt)
-			.routineType(routineType)
-			.user(user)
-			.completed(false)
-			.build();
 	}
 
 	public void addAuthor(User user) {
@@ -108,5 +95,9 @@ public class MainTask extends BaseEntity {
 
 	public void updateContent(String content) {
 		this.taskContent = content;
+	}
+
+	public void updateImportance(Importance importance) {
+		this.importance = importance;
 	}
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/repository/MainTaskRepository.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/repository/MainTaskRepository.java
@@ -1,8 +1,11 @@
 package com.sopt.todomate.domain.maintask.domain.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.sopt.todomate.domain.maintask.domain.entity.MainTask;
@@ -13,4 +16,9 @@ public interface MainTaskRepository extends JpaRepository<MainTask, Long> {
 	List<MainTask> findAllByUserAndTaskContent(User user, String content);
 
 	List<MainTask> findAllByTemplateTaskId(long templateId);
+
+	@Query("SELECT m FROM MainTask m WHERE m.templateTaskId = :templateId AND m.taskDate > :date")
+	List<MainTask> findAllByTemplateTaskIdAndTaskDateAfter(
+		@Param("templateId") long templateId,
+		@Param("date") LocalDateTime date);
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/repository/MainTaskRepository.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/repository/MainTaskRepository.java
@@ -11,4 +11,6 @@ import com.sopt.todomate.domain.user.domain.entity.User;
 @Repository
 public interface MainTaskRepository extends JpaRepository<MainTask, Long> {
 	List<MainTask> findAllByUserAndTaskContent(User user, String content);
+
+	List<MainTask> findAllByTemplateTaskId(long templateId);
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/service/MainTaskGetService.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/service/MainTaskGetService.java
@@ -1,5 +1,6 @@
 package com.sopt.todomate.domain.maintask.domain.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -21,5 +22,9 @@ public class MainTaskGetService {
 
 	public List<MainTask> findAllByTemplateId(long templateId) {
 		return mainTaskRepository.findAllByTemplateTaskId(templateId);
+	}
+
+	public List<MainTask> findAllByTemplateIdAndAfterDate(long templateId, LocalDateTime date) {
+		return mainTaskRepository.findAllByTemplateTaskIdAndTaskDateAfter(templateId, date);
 	}
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/service/MainTaskGetService.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/service/MainTaskGetService.java
@@ -1,0 +1,25 @@
+package com.sopt.todomate.domain.maintask.domain.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.sopt.todomate.domain.maintask.domain.entity.MainTask;
+import com.sopt.todomate.domain.maintask.domain.repository.MainTaskRepository;
+import com.sopt.todomate.domain.maintask.exception.MainTaskNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MainTaskGetService {
+	private final MainTaskRepository mainTaskRepository;
+
+	public MainTask findByMainTaskId(long mainTaskId) {
+		return mainTaskRepository.findById(mainTaskId).orElseThrow(MainTaskNotFoundException::new);
+	}
+
+	public List<MainTask> findAllByTemplateId(long templateId) {
+		return mainTaskRepository.findAllByTemplateTaskId(templateId);
+	}
+}

--- a/src/main/java/com/sopt/todomate/domain/maintask/exception/AccessDeniedException.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/exception/AccessDeniedException.java
@@ -1,0 +1,11 @@
+package com.sopt.todomate.domain.maintask.exception;
+
+import static com.sopt.todomate.global.common.exception.constant.ExceptionCode.*;
+
+import com.sopt.todomate.global.common.exception.BusinessException;
+
+public class AccessDeniedException extends BusinessException {
+	public AccessDeniedException() {
+		super(ACCESS_DENIED);
+	}
+}

--- a/src/main/java/com/sopt/todomate/domain/maintask/exception/InvalidImportanceException.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/exception/InvalidImportanceException.java
@@ -1,0 +1,11 @@
+package com.sopt.todomate.domain.maintask.exception;
+
+import static com.sopt.todomate.global.common.exception.constant.ExceptionCode.*;
+
+import com.sopt.todomate.global.common.exception.BusinessException;
+
+public class InvalidImportanceException extends BusinessException {
+	public InvalidImportanceException() {
+		super(INVALID_IMPORTANCE);
+	}
+}

--- a/src/main/java/com/sopt/todomate/domain/maintask/exception/MainTaskNotFoundException.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/exception/MainTaskNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sopt.todomate.domain.maintask.exception;
+
+import static com.sopt.todomate.global.common.exception.constant.ExceptionCode.*;
+
+import com.sopt.todomate.global.common.exception.BusinessException;
+
+public class MainTaskNotFoundException extends BusinessException {
+	public MainTaskNotFoundException() {
+		super(MAIN_TASK_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/sopt/todomate/domain/maintask/presentation/MainTaskController.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/presentation/MainTaskController.java
@@ -29,7 +29,7 @@ public class MainTaskController {
 	public ResponseDto<MainTaskCreateResponse> create(@RequestHeader Long userId,
 		@Valid @RequestBody MainTaskCreateRequest request) {
 		MainTaskCreateResponse response = mainTaskManageUsecase.execute(MainTaskCommand.from(request), userId);
-		return ResponseDto.ok(response);
+		return ResponseDto.created(response);
 	}
 
 	@PutMapping("/{taskId}")

--- a/src/main/java/com/sopt/todomate/domain/maintask/presentation/MainTaskController.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/presentation/MainTaskController.java
@@ -1,15 +1,19 @@
 package com.sopt.todomate.domain.maintask.presentation;
 
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sopt.todomate.domain.maintask.application.dto.MainTaskCommand;
+import com.sopt.todomate.domain.maintask.application.dto.MainTaskUpdateCommand;
 import com.sopt.todomate.domain.maintask.application.usecase.MainTaskManageUsecase;
 import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskCreateRequest;
 import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskCreateResponse;
+import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskUpdateRequest;
 import com.sopt.todomate.global.common.dto.ResponseDto;
 
 import jakarta.validation.Valid;
@@ -26,5 +30,13 @@ public class MainTaskController {
 		@Valid @RequestBody MainTaskCreateRequest request) {
 		MainTaskCreateResponse response = mainTaskManageUsecase.execute(MainTaskCommand.from(request), userId);
 		return ResponseDto.ok(response);
+	}
+
+	@PutMapping("/{taskId}")
+	public ResponseDto<Void> create(@RequestHeader Long userId, @PathVariable Long taskId,
+		@Valid @RequestBody MainTaskUpdateRequest request) {
+		mainTaskManageUsecase.update(taskId, MainTaskUpdateCommand.from(request),
+			userId);
+		return ResponseDto.okWithoutContent();
 	}
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskCreateRequest.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskCreateRequest.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.sopt.todomate.domain.maintask.domain.entity.CategoryType;
+import com.sopt.todomate.domain.maintask.domain.entity.Importance;
 import com.sopt.todomate.domain.maintask.domain.entity.RoutineType;
 
 import jakarta.validation.constraints.NotBlank;
@@ -16,7 +17,7 @@ public record MainTaskCreateRequest(
 	LocalDateTime endAt,
 	@NotNull(message = "루틴 종류는 비어있을 수 없습니다.")
 	RoutineType routineType,
-	long priority,
+	Importance importance,
 	@NotNull(message = "카테고리는 비어있을 수 없습니다.")
 	CategoryType category,
 	@NotNull(message = "일정 날짜는 비어있을 수 없습니다.")

--- a/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskCreateResponse.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskCreateResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.sopt.todomate.domain.maintask.domain.entity.CategoryType;
+import com.sopt.todomate.domain.maintask.domain.entity.Importance;
 import com.sopt.todomate.domain.maintask.domain.entity.MainTask;
 import com.sopt.todomate.domain.maintask.domain.entity.RoutineType;
 import com.sopt.todomate.domain.subtask.domain.entity.SubTask;
@@ -14,7 +15,7 @@ public record MainTaskCreateResponse(
 	LocalDateTime startAt,
 	LocalDateTime endAt,
 	RoutineType routineType,
-	long priority,
+	Importance importance,
 	CategoryType category,
 	LocalDateTime taskDate,
 	boolean completed,
@@ -31,7 +32,7 @@ public record MainTaskCreateResponse(
 			mainTask.getStartAt(),
 			mainTask.getEndAt(),
 			mainTask.getRoutineType(),
-			mainTask.getPriority(),
+			mainTask.getImportance(),
 			mainTask.getCategory(),
 			mainTask.getTaskDate(),
 			mainTask.isCompleted(),

--- a/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskUpdateRequest.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.sopt.todomate.domain.maintask.presentation.dto;
+
+import java.util.List;
+
+import com.sopt.todomate.domain.maintask.application.dto.SubTaskUpdateCommand;
+import com.sopt.todomate.domain.maintask.domain.entity.Importance;
+
+public record MainTaskUpdateRequest(
+	String taskContent,
+	List<SubTaskUpdateCommand> subTasks,
+	Importance importance,
+	boolean changeAll
+) {
+}

--- a/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskUpdateRequest.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskUpdateRequest.java
@@ -3,12 +3,10 @@ package com.sopt.todomate.domain.maintask.presentation.dto;
 import java.util.List;
 
 import com.sopt.todomate.domain.maintask.application.dto.SubTaskUpdateCommand;
-import com.sopt.todomate.domain.maintask.domain.entity.Importance;
 
 public record MainTaskUpdateRequest(
 	String taskContent,
 	List<SubTaskUpdateCommand> subTasks,
-	Importance importance,
 	boolean changeAll
 ) {
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskUpdateRequest.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskUpdateRequest.java
@@ -3,10 +3,12 @@ package com.sopt.todomate.domain.maintask.presentation.dto;
 import java.util.List;
 
 import com.sopt.todomate.domain.maintask.application.dto.SubTaskUpdateCommand;
+import com.sopt.todomate.domain.maintask.domain.entity.Importance;
 
 public record MainTaskUpdateRequest(
 	String taskContent,
 	List<SubTaskUpdateCommand> subTasks,
+	Importance importance,
 	boolean changeAll
 ) {
 }

--- a/src/main/java/com/sopt/todomate/domain/subtask/domain/entity/SubTask.java
+++ b/src/main/java/com/sopt/todomate/domain/subtask/domain/entity/SubTask.java
@@ -60,4 +60,8 @@ public class SubTask extends BaseEntity {
 		return this.completed;
 	}
 
+	public void updateContent(String content) {
+		this.content = content;
+	}
+
 }

--- a/src/main/java/com/sopt/todomate/domain/subtask/domain/entity/SubTask.java
+++ b/src/main/java/com/sopt/todomate/domain/subtask/domain/entity/SubTask.java
@@ -52,6 +52,14 @@ public class SubTask extends BaseEntity {
 			.build();
 	}
 
+	public static SubTask createCompletedFalse(String content, MainTask mainTask) {
+		return SubTask.builder()
+			.content(content)
+			.mainTask(mainTask)
+			.completed(false)
+			.build();
+	}
+
 	public void addMainTask(MainTask mainTask) {
 		this.mainTask = mainTask;
 	}

--- a/src/main/java/com/sopt/todomate/domain/subtask/domain/entity/SubTask.java
+++ b/src/main/java/com/sopt/todomate/domain/subtask/domain/entity/SubTask.java
@@ -52,14 +52,6 @@ public class SubTask extends BaseEntity {
 			.build();
 	}
 
-	public static SubTask createCompletedFalse(String content, MainTask mainTask) {
-		return SubTask.builder()
-			.content(content)
-			.mainTask(mainTask)
-			.completed(false)
-			.build();
-	}
-
 	public void addMainTask(MainTask mainTask) {
 		this.mainTask = mainTask;
 	}

--- a/src/main/java/com/sopt/todomate/domain/subtask/domain/repository/SubTaskRepository.java
+++ b/src/main/java/com/sopt/todomate/domain/subtask/domain/repository/SubTaskRepository.java
@@ -11,4 +11,6 @@ import com.sopt.todomate.domain.subtask.domain.entity.SubTask;
 @Repository
 public interface SubTaskRepository extends JpaRepository<SubTask, Long> {
 	List<SubTask> findAllByMainTask(MainTask mainTask);
+
+	void deleteAllByMainTask(MainTask mainTask);
 }

--- a/src/main/java/com/sopt/todomate/domain/subtask/domain/service/SubTaskDeleteService.java
+++ b/src/main/java/com/sopt/todomate/domain/subtask/domain/service/SubTaskDeleteService.java
@@ -1,0 +1,18 @@
+package com.sopt.todomate.domain.subtask.domain.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sopt.todomate.domain.maintask.domain.entity.MainTask;
+import com.sopt.todomate.domain.subtask.domain.repository.SubTaskRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SubTaskDeleteService {
+	private final SubTaskRepository subTaskRepository;
+
+	public void deleteAllByMainTask(MainTask mainTask) {
+		subTaskRepository.deleteAllByMainTask(mainTask);
+	}
+}

--- a/src/main/java/com/sopt/todomate/domain/subtask/domain/service/SubTaskGetService.java
+++ b/src/main/java/com/sopt/todomate/domain/subtask/domain/service/SubTaskGetService.java
@@ -1,0 +1,28 @@
+package com.sopt.todomate.domain.subtask.domain.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.sopt.todomate.domain.maintask.domain.entity.MainTask;
+import com.sopt.todomate.domain.maintask.domain.repository.MainTaskRepository;
+import com.sopt.todomate.domain.subtask.domain.entity.SubTask;
+import com.sopt.todomate.domain.subtask.domain.repository.SubTaskRepository;
+import com.sopt.todomate.domain.subtask.exception.SubTaskNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SubTaskGetService {
+	private final SubTaskRepository subTaskRepository;
+	private final MainTaskRepository mainTaskRepository;
+
+	public List<SubTask> findAllByMainTask(MainTask mainTask) {
+		return subTaskRepository.findAllByMainTask(mainTask);
+	}
+
+	public SubTask findSubTaskById(long subTaskId) {
+		return subTaskRepository.findById(subTaskId).orElseThrow(SubTaskNotFoundException::new);
+	}
+}

--- a/src/main/java/com/sopt/todomate/domain/subtask/domain/service/SubTaskUpdateService.java
+++ b/src/main/java/com/sopt/todomate/domain/subtask/domain/service/SubTaskUpdateService.java
@@ -1,0 +1,17 @@
+package com.sopt.todomate.domain.subtask.domain.service;
+
+import org.springframework.stereotype.Service;
+
+import com.sopt.todomate.domain.subtask.domain.repository.SubTaskRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SubTaskUpdateService {
+	private final SubTaskRepository subTaskRepository;
+
+	public void updateSubTask() {
+
+	}
+}

--- a/src/main/java/com/sopt/todomate/domain/subtask/exception/MaxSubTaskException.java
+++ b/src/main/java/com/sopt/todomate/domain/subtask/exception/MaxSubTaskException.java
@@ -1,0 +1,11 @@
+package com.sopt.todomate.domain.subtask.exception;
+
+import static com.sopt.todomate.global.common.exception.constant.ExceptionCode.*;
+
+import com.sopt.todomate.global.common.exception.BusinessException;
+
+public class MaxSubTaskException extends BusinessException {
+	public MaxSubTaskException() {
+		super(MAX_SUBTASK);
+	}
+}

--- a/src/main/java/com/sopt/todomate/domain/subtask/exception/SubTaskNotFoundException.java
+++ b/src/main/java/com/sopt/todomate/domain/subtask/exception/SubTaskNotFoundException.java
@@ -1,0 +1,11 @@
+package com.sopt.todomate.domain.subtask.exception;
+
+import static com.sopt.todomate.global.common.exception.constant.ExceptionCode.*;
+
+import com.sopt.todomate.global.common.exception.BusinessException;
+
+public class SubTaskNotFoundException extends BusinessException {
+	public SubTaskNotFoundException() {
+		super(SUB_TASK_NOT_FOUND);
+	}
+}

--- a/src/main/java/com/sopt/todomate/domain/subtask/exception/SubTaskNotIncludeException.java
+++ b/src/main/java/com/sopt/todomate/domain/subtask/exception/SubTaskNotIncludeException.java
@@ -1,0 +1,10 @@
+package com.sopt.todomate.domain.subtask.exception;
+
+import com.sopt.todomate.global.common.exception.BusinessException;
+import com.sopt.todomate.global.common.exception.constant.ExceptionCode;
+
+public class SubTaskNotIncludeException extends BusinessException {
+	public SubTaskNotIncludeException() {
+		super(ExceptionCode.SUB_TASK_NOT_INCLUDED);
+	}
+}

--- a/src/main/java/com/sopt/todomate/global/common/exception/constant/ExceptionCode.java
+++ b/src/main/java/com/sopt/todomate/global/common/exception/constant/ExceptionCode.java
@@ -16,6 +16,7 @@ public enum ExceptionCode {
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "c4042", "사용자가 존재하지 않습니다."),
 	MAIN_TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "c4043", "메인 태스크가 존재하지 않습니다."),
 	SUB_TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "c4044", "서브 태스크가 존재하지 않습니다."),
+	SUB_TASK_NOT_INCLUDED(HttpStatus.NOT_FOUND, "c40441", "서브태스크가 해당 메인태스크에 속하지 않습니다."),
 
 	//405
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "c4050", "잘못된 HTTP method 요청입니다."),

--- a/src/main/java/com/sopt/todomate/global/common/exception/constant/ExceptionCode.java
+++ b/src/main/java/com/sopt/todomate/global/common/exception/constant/ExceptionCode.java
@@ -11,6 +11,7 @@ public enum ExceptionCode {
 	INVALID_CATEGORY_TYPE(HttpStatus.BAD_REQUEST, "c40012", "유효하지 않은 카테고리 타입 입니다."),
 	INVALID_IMPORTANCE(HttpStatus.BAD_REQUEST, "c40013", "유효하지 않은 중요도 타입 입니다."),
 	EMPTY_ROUTINE_DATE(HttpStatus.BAD_REQUEST, "c40021", "루틴 생성시 날짜는 모두 입력되어야 합니다."),
+	MAX_SUBTASK(HttpStatus.BAD_REQUEST, "c40022", "서브테스크는 3개이상 생성할 수 없습니다."),
 
 	//403
 	ACCESS_DENIED(HttpStatus.FORBIDDEN, "c40310", "다른 사람의 투두는 수정할 수 없습니다."),

--- a/src/main/java/com/sopt/todomate/global/common/exception/constant/ExceptionCode.java
+++ b/src/main/java/com/sopt/todomate/global/common/exception/constant/ExceptionCode.java
@@ -9,6 +9,7 @@ public enum ExceptionCode {
 	EMPTY_USER_ID(HttpStatus.BAD_REQUEST, "c40010", "유저ID는 필수입니다."),
 	INVALID_ROUTINE_TYPE(HttpStatus.BAD_REQUEST, "c40011", "유효하지 않은 루틴타입 입니다."),
 	INVALID_CATEGORY_TYPE(HttpStatus.BAD_REQUEST, "c40012", "유효하지 않은 카테고리 타입 입니다."),
+	INVALID_IMPORTANCE(HttpStatus.BAD_REQUEST, "c40013", "유효하지 않은 중요도 타입 입니다."),
 	EMPTY_ROUTINE_DATE(HttpStatus.BAD_REQUEST, "c40021", "루틴 생성시 날짜는 모두 입력되어야 합니다."),
 
 	//404

--- a/src/main/java/com/sopt/todomate/global/common/exception/constant/ExceptionCode.java
+++ b/src/main/java/com/sopt/todomate/global/common/exception/constant/ExceptionCode.java
@@ -14,6 +14,8 @@ public enum ExceptionCode {
 	//404
 	NOT_FOUND(HttpStatus.NOT_FOUND, "c4040", "리소스가 존재하지 않습니다."),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "c4042", "사용자가 존재하지 않습니다."),
+	MAIN_TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "c4043", "메인 태스크가 존재하지 않습니다."),
+	SUB_TASK_NOT_FOUND(HttpStatus.NOT_FOUND, "c4044", "서브 태스크가 존재하지 않습니다."),
 
 	//405
 	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "c4050", "잘못된 HTTP method 요청입니다."),

--- a/src/main/java/com/sopt/todomate/global/common/exception/constant/ExceptionCode.java
+++ b/src/main/java/com/sopt/todomate/global/common/exception/constant/ExceptionCode.java
@@ -12,6 +12,9 @@ public enum ExceptionCode {
 	INVALID_IMPORTANCE(HttpStatus.BAD_REQUEST, "c40013", "유효하지 않은 중요도 타입 입니다."),
 	EMPTY_ROUTINE_DATE(HttpStatus.BAD_REQUEST, "c40021", "루틴 생성시 날짜는 모두 입력되어야 합니다."),
 
+	//403
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "c40310", "다른 사람의 투두는 수정할 수 없습니다."),
+
 	//404
 	NOT_FOUND(HttpStatus.NOT_FOUND, "c4040", "리소스가 존재하지 않습니다."),
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "c4042", "사용자가 존재하지 않습니다."),

--- a/src/test/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecaseTest.java
+++ b/src/test/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecaseTest.java
@@ -265,7 +265,6 @@ public class MainTaskManageUsecaseTest {
 		MainTaskUpdateCommand mainTaskUpdateCommand = new MainTaskUpdateCommand(
 			"변경하는 태스크",
 			List.of(new SubTaskUpdateCommand("통합테스트 서브태스크", true)),
-			MEDIUM,
 			false
 		);
 
@@ -309,7 +308,6 @@ public class MainTaskManageUsecaseTest {
 			"변경하는 태스크",
 			List.of(new SubTaskUpdateCommand("통합테스트 서브태스크", true), new SubTaskUpdateCommand("통합테스트 서브태스크2", true),
 				new SubTaskUpdateCommand("통합테스트 서브태스크3", true), new SubTaskUpdateCommand("통합테스트 서브태스크4", true)),
-			MEDIUM,
 			false
 		);
 
@@ -350,7 +348,7 @@ public class MainTaskManageUsecaseTest {
 			"통합테스트 태스크",
 			List.of(new SubTaskUpdateCommand("변경된 서브태스크", true),
 				new SubTaskUpdateCommand("변경된 서브태스크2", false)),
-			MEDIUM, false
+			false
 		);
 
 		//when
@@ -401,7 +399,7 @@ public class MainTaskManageUsecaseTest {
 			"변경된 태스크 제목",
 			List.of(new SubTaskUpdateCommand("변경된 서브태스크", true),
 				new SubTaskUpdateCommand("변경된 서브태스크2", false)),
-			MEDIUM, true
+			true
 		);
 
 		//when
@@ -464,7 +462,7 @@ public class MainTaskManageUsecaseTest {
 		MainTaskUpdateCommand mainTaskUpdateCommand = new MainTaskUpdateCommand(
 			"변경된 태스크 제목",
 			List.of(new SubTaskUpdateCommand("변경된 서브태스크", true)),
-			MEDIUM, true
+			true
 		);
 
 		//when
@@ -529,7 +527,7 @@ public class MainTaskManageUsecaseTest {
 			"변경된 태스크 제목",
 			List.of(new SubTaskUpdateCommand("변경된 서브태스크", true),
 				new SubTaskUpdateCommand("새로 추가한 서브태스크", false)),
-			MEDIUM, true
+			true
 		);
 
 		//when
@@ -600,12 +598,12 @@ public class MainTaskManageUsecaseTest {
 			"변경된 태스크 제목",
 			List.of(new SubTaskUpdateCommand("변경된 서브태스크", true),
 				new SubTaskUpdateCommand("새로 추가한 서브태스크", false)),
-			MEDIUM, true
+			true
 		);
 
 		//when & then
 		assertThatThrownBy(
-			() -> mainTaskManageUsecase.update(response.mainTaskId(), mainTaskUpdateCommand, testUser2.getId()))
+			() -> mainTaskManageUsecase.update(response.mainTaskId(), mainTaskUpdateCommand, savedUser2.getId()))
 			.isInstanceOf(AccessDeniedException.class);
 
 	}

--- a/src/test/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecaseTest.java
+++ b/src/test/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecaseTest.java
@@ -275,7 +275,7 @@ public class MainTaskManageUsecaseTest {
 		MainTaskUpdateCommand mainTaskUpdateCommand = new MainTaskUpdateCommand(
 			"통합테스트 태스크",
 			List.of(new SubTaskUpdateCommand(response.subTasks().get(0).subTaskId(), "변경된 서브태스크"),
-				new SubTaskUpdateCommand(response.subTasks().get(2).subTaskId(), "변경된 서브태스크2")),
+				new SubTaskUpdateCommand(response.subTasks().get(1).subTaskId(), "변경된 서브태스크2")),
 			false
 		);
 

--- a/src/test/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecaseTest.java
+++ b/src/test/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecaseTest.java
@@ -265,7 +265,7 @@ public class MainTaskManageUsecaseTest {
 		MainTaskUpdateCommand mainTaskUpdateCommand = new MainTaskUpdateCommand(
 			"변경하는 태스크",
 			List.of(new SubTaskUpdateCommand("통합테스트 서브태스크", true)),
-			false
+			MEDIUM, false
 		);
 
 		//when
@@ -308,7 +308,7 @@ public class MainTaskManageUsecaseTest {
 			"변경하는 태스크",
 			List.of(new SubTaskUpdateCommand("통합테스트 서브태스크", true), new SubTaskUpdateCommand("통합테스트 서브태스크2", true),
 				new SubTaskUpdateCommand("통합테스트 서브태스크3", true), new SubTaskUpdateCommand("통합테스트 서브태스크4", true)),
-			false
+			MEDIUM, false
 		);
 
 		//when & then
@@ -348,6 +348,7 @@ public class MainTaskManageUsecaseTest {
 			"통합테스트 태스크",
 			List.of(new SubTaskUpdateCommand("변경된 서브태스크", true),
 				new SubTaskUpdateCommand("변경된 서브태스크2", false)),
+			MEDIUM,
 			false
 		);
 
@@ -399,6 +400,7 @@ public class MainTaskManageUsecaseTest {
 			"변경된 태스크 제목",
 			List.of(new SubTaskUpdateCommand("변경된 서브태스크", true),
 				new SubTaskUpdateCommand("변경된 서브태스크2", false)),
+			MEDIUM,
 			true
 		);
 
@@ -462,6 +464,7 @@ public class MainTaskManageUsecaseTest {
 		MainTaskUpdateCommand mainTaskUpdateCommand = new MainTaskUpdateCommand(
 			"변경된 태스크 제목",
 			List.of(new SubTaskUpdateCommand("변경된 서브태스크", true)),
+			MEDIUM,
 			true
 		);
 
@@ -527,6 +530,7 @@ public class MainTaskManageUsecaseTest {
 			"변경된 태스크 제목",
 			List.of(new SubTaskUpdateCommand("변경된 서브태스크", true),
 				new SubTaskUpdateCommand("새로 추가한 서브태스크", false)),
+			MEDIUM,
 			true
 		);
 
@@ -598,6 +602,7 @@ public class MainTaskManageUsecaseTest {
 			"변경된 태스크 제목",
 			List.of(new SubTaskUpdateCommand("변경된 서브태스크", true),
 				new SubTaskUpdateCommand("새로 추가한 서브태스크", false)),
+			MEDIUM,
 			true
 		);
 


### PR DESCRIPTION
## 🚀 PR 요약
태스크를 수정하는 API를 구현했습니다.

## ✨ PR 상세 내용
1. 수정 API는 한 번에 메인 태스크 변경, 서브 태스크 생성 및 삭제 는 한 플로우에서 일어나기 때문에 따로 요청을 받기보다 한번에 메인 태스크와 서브태스크를 입력받는 방식으로 구현하였습니다.
2. 다른 사용자의 할 일을 수정하지 못하게 하는 방어로직을 구현했습니다.
3. 서브 태스크를 세 개 이상 수정할 경우 예외를 발생하도록 코드를 변경했습니다.
4. 중요도로 요구사항이 변경되어 priority를 삭제하고 Importance 를 추가하였습니다. 

## 🚨 주의 사항

서브태스크는 따로 정렬하는 파라미터가 없어 삭제 -> 생성하는 방식으로 업데이트를 구현했습니다.
추후 가능하다면 서브태스크의 메인테스크의 id + 내용을 기준으로 select하여 id를 추출하는 방식을 고려해보겠습니다

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?

close #7 
