### PR TITLE
[feat] 메인태스크 완료여부 변경 API 구현

### DIFF
--- a/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskCompletedCommand.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/dto/MainTaskCompletedCommand.java
@@ -1,0 +1,11 @@
+package com.sopt.todomate.domain.maintask.application.dto;
+
+import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskCompletedRequest;
+
+public record MainTaskCompletedCommand (
+	Boolean completed
+) {
+	public static MainTaskCompletedCommand from(MainTaskCompletedRequest request) {
+		return new MainTaskCompletedCommand(request.completed());
+	}
+}

--- a/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/application/usecase/MainTaskManageUsecase.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.sopt.todomate.domain.maintask.application.dto.MainTaskCommand;
+import com.sopt.todomate.domain.maintask.application.dto.MainTaskCompletedCommand;
 import com.sopt.todomate.domain.maintask.application.dto.MainTaskUpdateCommand;
 import com.sopt.todomate.domain.maintask.application.dto.SubTaskUpdateCommand;
 import com.sopt.todomate.domain.maintask.domain.entity.MainTask;
@@ -133,5 +134,12 @@ public class MainTaskManageUsecase {
 			.toList();
 
 		subTaskSaveService.saveAll(subTasks);
+	}
+
+	@Transactional
+	public void updateCompleted(long userId, long mainTaskId, MainTaskCompletedCommand command) {
+		User user = userGetService.findByUserId(userId);
+		MainTask mainTask = checkAuthorityByMainTaskId(mainTaskId, user);
+		mainTask.updateCompleted(command.completed());
 	}
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/MainTask.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/domain/entity/MainTask.java
@@ -102,6 +102,10 @@ public class MainTask extends BaseEntity {
 		return this.completed;
 	}
 
+	public void updateCompleted(boolean completed) {
+		this.completed = completed;
+	}
+
 	public void updateTemplateTask(long id) {
 		this.templateTaskId = id;
 	}

--- a/src/main/java/com/sopt/todomate/domain/maintask/presentation/MainTaskController.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/presentation/MainTaskController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -16,9 +17,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sopt.todomate.domain.maintask.application.dto.MainTaskCommand;
+import com.sopt.todomate.domain.maintask.application.dto.MainTaskCompletedCommand;
 import com.sopt.todomate.domain.maintask.application.dto.MainTaskUpdateCommand;
 import com.sopt.todomate.domain.maintask.application.usecase.MainTaskManageUsecase;
 import com.sopt.todomate.domain.maintask.application.usecase.MainTaskQueryUsecase;
+import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskCompletedRequest;
 import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskCreateRequest;
 import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskCreateResponse;
 import com.sopt.todomate.domain.maintask.presentation.dto.MainTaskDetailResponse;
@@ -84,6 +87,16 @@ public class MainTaskController {
 	@Operation(summary = "자신의 모든 메인태스크를 삭제")
 	public ResponseDto<Void> deleteAll(@RequestHeader Long userId) {
 		mainTaskManageUsecase.deleteAll(userId);
+		return ResponseDto.noContent();
+	}
+
+	@PatchMapping()
+	public ResponseDto<Void> updateMainTaskCompleted(
+		@RequestHeader Long userId,
+		@RequestHeader Long taskId,
+		@Valid @RequestBody MainTaskCompletedRequest request) {
+		mainTaskManageUsecase.updateCompleted(userId, taskId,
+			MainTaskCompletedCommand.from(request));
 		return ResponseDto.noContent();
 	}
 }

--- a/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskCompletedRequest.java
+++ b/src/main/java/com/sopt/todomate/domain/maintask/presentation/dto/MainTaskCompletedRequest.java
@@ -1,0 +1,8 @@
+package com.sopt.todomate.domain.maintask.presentation.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record MainTaskCompletedRequest(
+	@NotNull Boolean completed
+) {
+}


### PR DESCRIPTION
## 🚀 PR 요약
메인태스크 완료여부를 변경하는 API를 구현했습니다.

## ✨ PR 상세 내용
- 서브태스크를 구현한 방식과 비슷한 코드 형상으로 메인태스크 완료여부 변경 API를 구현하였습니다.

## 🚨 주의 사항
딱히 없습니다.

## ✅ 체크 리스트

- [x] 리뷰어 설정했나요?
- [x] Label 설정했나요?
- [x] 제목 양식 맞췄나요? (ex. [feat] 기능 추가)
- [x] 변경 사항에 대한 테스트 진행했나요?

close #18 
